### PR TITLE
changed dockerfile to use package node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# use iojs
-FROM iojs
+# use node
+FROM node
 # default port 80
 ENV PORT 80
 # expost default port 80


### PR DESCRIPTION
iojs merged back with node into version 4.0.0 and iojs will not be
releasing any more builds. To conform node should be the default parent
container again.
