### PR TITLE
added g++-4.9 to build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 ---
 language: node_js
 node_js:
-    - "iojs-v2.5"
-    - "0.12"
+    - "iojs-v3"
+    - "4"
+env:
+    - CXX=g++-4.9
+addons:
+    apt:
+        sources:
+            - ubuntu-toolchain-r-test
+        packages:
+            - g++-4.9
 branches:
     except:
         - circleci
@@ -18,6 +26,8 @@ services:
     - mongodb
     - redis-server
 before_install:
+    - $CXX --version
+    - npm install -g npm
     - npm install coveralls
 before_script:
     - gulp build

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 ---
 machine:
   node:
-    version: iojs-v2.5
+    version: iojs-v3
   services:
     - mongodb
     - redis
@@ -13,6 +13,10 @@ machine:
     redis: "redis://:test@localhost/0"
 dependencies:
   pre:
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test && sudo apt-get update
+    - sudo apt-get install -y gcc-4.9 g++-4.9
+    - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 20
+    - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 20
     - npm i -g gulp livescript mocha
   cache_directories:
     - "node_modules"


### PR DESCRIPTION
node4 and probably iojs3 require a higher version of g++ than travis and
circleci provide by default. This attempts to force them to update to a
compatible version.
