### PR TITLE
added img-src content security policy

### DIFF
--- a/src/app.ls
+++ b/src/app.ls
@@ -118,6 +118,12 @@ app
 			"maxcdn.bootstrapcdn.com",
 			"cdnjs.cloudflare.com"
 		]
+		img-src:     ["'self'",
+			"lissome.co"
+			"assets.lissome.co",
+			"maxcdn.bootstrapcdn.com",
+			"cdnjs.cloudflare.com"
+		]
 		script-src:  ["'self'",
 			"assets.lissome.co",
 			"maxcdn.bootstrapcdn.com",


### PR DESCRIPTION
maxcdn and cdnjs need to be allowed for fonts and icons within
the fonts. assets may also eventually contain those fonts also.
