### PR TITLE
added rm -rf ./node_modules

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,7 @@
 build:
 	npm i
 	gulp build
+	rm -rf ./node_modules/
 	npm i
 
 test:
@@ -14,6 +15,6 @@ coverage:
 	./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha
 
 clean:
-	rm -rf ./lib/
+	rm -rf ./lib/ ./node_modules/
 
 .PHONY: default build test coverage clean


### PR DESCRIPTION
this is apparently recommended in npm v3 or greater.

see
https://docs.npmjs.com/how-npm-works/npm3-nondet#i-want-my-node-modules-directory-to-be-the-same-how-can-i-do-that
for details.
